### PR TITLE
2 instructions dont cd back to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.venv

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ For  now I've only tested this on a linux machine (Ubuntu 22 in my case)
 ```
 #clone the repo
 git clone https://github.com/aedocw/epub2tts
-#create a virtual environment
-python3 -m venv epub2tts
 cd epub2tts
+#create a virtual environment
+python3 -m venv .venv
 #activate the virtual environment
-source bin/activate
+source .venv/bin/activate
 #install dependencies
 sudo apt install espeak-ng ffmpeg
 pip3 install -r requirements.txt


### PR DESCRIPTION
Instructions were bad and asked you to create a venv in root of project. Updated to suggest creating it in hidden directory .venv, and added that to .gitignore