### PR TITLE
Skip the links

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -51,8 +51,8 @@ for item in book.get_items():
 chapters_to_read = []
 for i in range(len(chapters)):
     #strip some characters that might have caused TTS to choke
-    text = text.translate({ord(c): None for c in '[]'})
     text=chap2text(chapters[i])
+    text = text.translate({ord(c): None for c in '[]'})
     if len(text) < 150:
         #too short to bother with
         continue

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -23,6 +23,9 @@ model_name = "tts_models/en/vctk/vits"
 def chap2text(chap):
     output = ''
     soup = BeautifulSoup(chap, 'html.parser')
+    #Remove everything that is an href
+    for a in soup.findAll('a', href=True):
+        a.extract()
     text = soup.find_all(text=True)
     for t in text:
         if t.parent.name not in blacklist:


### PR DESCRIPTION
This seems to work. Removes links in their entirety, so text like:
This is the text <a href="footnote10.html">[10]</a>
becomes:
This is the text.

It may have undesired side effect of removing copy that you want, but so far none of the epubs I've tested with have had anything other than footnotes or table of content pages that were links.