### PR TITLE
bring back breaking up text into chunks

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -138,7 +138,13 @@ class EpubToAudiobook:
     def get_chapters_text(self):
         with open(self.source, 'r') as file:
             text = file.read()
-        print(text[:256])
+        max_len = 50000
+        while len(text) > max_len:
+            pos = text.rfind(' ', 0, max_len)  # find the last space within the limit
+            self.chapters_to_read.append(text[:pos])
+            print("Part: " + str(len(self.chapters_to_read)))
+            print(str(self.chapters_to_read[-1])[:256])
+            text = text[pos+1:]  # +1 to avoid starting the next chapter with a space
         self.chapters_to_read.append(text)
         self.end = len(self.chapters_to_read)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='doc@aedo.net',
     url='https://github.com/aedocw/epub2tts',
     license='Apache License, Version 2.0',
-    version='2.0.8',
+    version='2.0.9',
     packages=find_packages(),
     install_requires=requirements,
     py_modules=['epub2tts'],


### PR DESCRIPTION
This should have stayed in here in the first place. When reading from a txt file (rather than epub), it is unable to detect chapters, so it breaks the text up every 50000 characters instead. Probably will make that 30k characters in the future.