### PR TITLE
Use FLAC for temp files

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -362,7 +362,7 @@ class EpubToAudiobook:
         self.generate_metadata(files, title, author)
         ffmpeg_command = ["ffmpeg","-i",outputm4a,"-i",self.ffmetadatafile,"-map_metadata","1","-codec","copy",self.output_filename]
         subprocess.run(ffmpeg_command)
-        #os.remove(self.ffmetadatafile)
+        os.remove(self.ffmetadatafile)
         os.remove(outputm4a)
         for f in files:
             os.remove(f)

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -308,7 +308,7 @@ class EpubToAudiobook:
                         temp.export(tempflac, format="flac")
                         #os.remove(tempwav)
                     tempfiles.append(tempflac)
-                tempflacfiles = [AudioSegment.from_flac(f"{f}") for f in tempfiles]
+                tempflacfiles = [AudioSegment.from_file(f"{f}") for f in tempfiles]
                 concatenated = sum(tempflacfiles)
                 concatenated.export(outputflac, format="flac")
                 #for f in tempfiles:

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -269,10 +269,7 @@ class EpubToAudiobook:
             if os.path.isfile(outputmp3):
                 print(outputmp3 + " exists, skipping to next chapter")
             else:
-                #print("Debug is " + str(self.debug))
                 tempfiles = []
-                #segmenter = pysbd.Segmenter(language="en", clean=True)
-                #sentences = segmenter.segment(self.chapters_to_read[i])
                 sentences = sent_tokenize(self.chapters_to_read[i])
                 sentence_groups = list(self.combine_sentences(sentences))
                 for x in tqdm(range(len(sentence_groups))):
@@ -310,12 +307,10 @@ class EpubToAudiobook:
                         temp = AudioSegment.from_wav(tempwav)
                         temp.export(tempmp3, format="mp3")
                         os.remove(tempwav)
-                    #tempfiles.append(tempwav)
                     tempfiles.append(tempmp3)
-                tempwavfiles = [AudioSegment.from_mp3(f"{f}") for f in tempfiles]
-                concatenated = sum(tempwavfiles)
-                normalized = effects.normalize(concatenated)
-                normalized.export(outputmp3, format="mp3")
+                tempmp3files = [AudioSegment.from_mp3(f"{f}") for f in tempfiles]
+                concatenated = sum(tempmp3files)
+                concatenated.export(outputmp3, format="mp3")
                 for f in tempfiles:
                     os.remove(f)
             files.append(outputmp3)

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -81,7 +81,7 @@ class EpubToAudiobook:
                 start_time += duration
     
     def get_duration(self, file_path):
-        audio = AudioSegment.from_flac(file_path)
+        audio = AudioSegment.from_file(file_path)
         duration_milliseconds = len(audio)
         return duration_milliseconds
 
@@ -326,7 +326,7 @@ class EpubToAudiobook:
             torch.cuda.empty_cache()
         # Load all WAV files and concatenate into one object
         #wav_files = [AudioSegment.from_wav(f"{f}") for f in files]
-        flac_files = [AudioSegment.from_flac(f"{f}") for f in files]
+        flac_files = [AudioSegment.from_file(f"{f}") for f in files]
 
         one_sec_silence = AudioSegment.silent(duration=1000)
         concatenated = AudioSegment.empty()

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -81,7 +81,7 @@ class EpubToAudiobook:
                 start_time += duration
     
     def get_duration(self, file_path):
-        audio = AudioSegment.from_ogg(file_path)
+        audio = AudioSegment.from_flac(file_path)
         duration_milliseconds = len(audio)
         return duration_milliseconds
 
@@ -265,9 +265,9 @@ class EpubToAudiobook:
         start_time = time.time()
         print("Reading from " + str(self.start + 1) + " to " + str(self.end))
         for i in range(self.start, self.end):
-            outputogg = self.bookname + "-" + str(i+1) + "ogg"
-            if os.path.isfile(outputogg):
-                print(outputogg + " exists, skipping to next chapter")
+            outputflac = self.bookname + "-" + str(i+1) + "flac"
+            if os.path.isfile(outputflac):
+                print(outputflac + " exists, skipping to next chapter")
             else:
                 tempfiles = []
                 sentences = sent_tokenize(self.chapters_to_read[i])
@@ -275,9 +275,9 @@ class EpubToAudiobook:
                 for x in tqdm(range(len(sentence_groups))):
                     retries = 1
                     tempwav = "temp" + str(x) + ".wav"
-                    tempogg = tempwav.replace("wav", "ogg")
-                    if os.path.isfile(tempogg):
-                        print(tempogg + " exists, skipping to next chunk")
+                    tempflac = tempwav.replace("wav", "flac")
+                    if os.path.isfile(tempflac):
+                        print(tempflac + " exists, skipping to next chunk")
                     else:
                         while retries > 0:
                             try:
@@ -305,15 +305,15 @@ class EpubToAudiobook:
                             print("Something is wrong with the audio (" + str(ratio) + "): " + tempwav)
                             #sys.exit()
                         temp = AudioSegment.from_wav(tempwav)
-                        temp.export(tempogg, format="ogg")
+                        temp.export(tempflac, format="flac")
                         #os.remove(tempwav)
-                    tempfiles.append(tempogg)
-                tempoggfiles = [AudioSegment.from_ogg(f"{f}") for f in tempfiles]
-                concatenated = sum(tempoggfiles)
-                concatenated.export(outputogg, format="ogg")
+                    tempfiles.append(tempflac)
+                tempflacfiles = [AudioSegment.from_flac(f"{f}") for f in tempfiles]
+                concatenated = sum(tempflacfiles)
+                concatenated.export(outputflac, format="flac")
                 #for f in tempfiles:
                 #    os.remove(f)
-            files.append(outputogg)
+            files.append(outputflac)
             position += len(self.chapters_to_read[i])
             percentage = (position / total_chars) * 100
             print(f"{percentage:.2f}% spoken so far.")
@@ -326,12 +326,12 @@ class EpubToAudiobook:
             torch.cuda.empty_cache()
         # Load all WAV files and concatenate into one object
         #wav_files = [AudioSegment.from_wav(f"{f}") for f in files]
-        ogg_files = [AudioSegment.from_ogg(f"{f}") for f in files]
+        flac_files = [AudioSegment.from_flac(f"{f}") for f in files]
 
         one_sec_silence = AudioSegment.silent(duration=1000)
         concatenated = AudioSegment.empty()
-        print("Replacing silences longer than one second with one second of silence (" + str(len(ogg_files)) + " files)")
-        for audio in ogg_files:
+        print("Replacing silences longer than one second with one second of silence (" + str(len(flac_files)) + " files)")
+        for audio in flac_files:
             # Split audio into chunks where detected silence is longer than one second
             chunks = split_on_silence(audio, min_silence_len=1000, silence_thresh=-50)
             # Iterate through each chunk

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -306,13 +306,13 @@ class EpubToAudiobook:
                             #sys.exit()
                         temp = AudioSegment.from_wav(tempwav)
                         temp.export(tempflac, format="flac")
-                        #os.remove(tempwav)
+                        os.remove(tempwav)
                     tempfiles.append(tempflac)
                 tempflacfiles = [AudioSegment.from_file(f"{f}") for f in tempfiles]
                 concatenated = sum(tempflacfiles)
                 concatenated.export(outputflac, format="flac")
-                #for f in tempfiles:
-                #    os.remove(f)
+                for f in tempfiles:
+                    os.remove(f)
             files.append(outputflac)
             position += len(self.chapters_to_read[i])
             percentage = (position / total_chars) * 100
@@ -324,8 +324,7 @@ class EpubToAudiobook:
             print(f"Elapsed: {int(elapsed_time / 60)} minutes, ETA: {int((estimated_time_remaining) / 60)} minutes")
             gc.collect()
             torch.cuda.empty_cache()
-        # Load all WAV files and concatenate into one object
-        #wav_files = [AudioSegment.from_wav(f"{f}") for f in files]
+        # Load all FLAC files and concatenate into one object
         flac_files = [AudioSegment.from_file(f"{f}") for f in files]
 
         one_sec_silence = AudioSegment.silent(duration=1000)
@@ -351,8 +350,8 @@ class EpubToAudiobook:
         subprocess.run(ffmpeg_command)
         os.remove(self.ffmetadatafile)
         os.remove(outputm4a)
-        #for f in files:
-        #    os.remove(f)
+        for f in files:
+            os.remove(f)
         print(self.output_filename + " complete")
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='doc@aedo.net',
     url='https://github.com/aedocw/epub2tts',
     license='Apache License, Version 2.0',
-    version='2.0.10',
+    version='2.1.0',
     packages=find_packages(),
     install_requires=requirements,
     py_modules=['epub2tts'],


### PR DESCRIPTION
This branch is wrongly named, but originally I thought I would just use mp3 files for temp, unfortunately that introduced audio artifacts (possibly could have worked on ffmpeg parameters to tune it better, but...) Converting the intermediate wav files to flac though is clean and results in files less than half the original size.