### PR TITLE
Replace double spaces in the final combined sentence

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -263,7 +263,7 @@ class EpubToAudiobook:
             else:
                 yield combined
                 combined = sentence
-        yield combined
+        yield combined.replace("  ", " ")
 
     def read_book(self, voice_samples, engine, openai, model_name, speaker, bitrate):
         self.model_name = model_name


### PR DESCRIPTION
The use of the sample.txt text reveals that double spaces sometimes occur when combining sentences. To prevent this, we should remove them.

Before:
['This script takes an epub (or text file) and reads it to an m4b audiobook file,**DoubleSpace**using TTS by Coqui or OpenAI.',

After:
['This script takes an epub (or text file) and reads it to an m4b audiobook file, using TTS by Coqui or OpenAI.', 