### PR TITLE
Optional whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ To specify which chapter to end on (ex 20): `--end 20`
 
 To specify bitrate (ex 30k): `--bitrate 30k`
 
+To specify minimum comparison ratio between transcript of spoken text and original, default 88. Set to 0 to disable this comparison with whisper: `--minratio 95`
+
 If epub2tts is interrupted or crashes, you can run it again with the same parameters and it will pick up where it left off, assuming it made it far enough to save some WAV files. If you want to start fresh, be sure to delete any of the wav files (with the same name as the epub) in the working directory before running again.
 
 ## DOCKER INSTRUCTIONS:

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -303,12 +303,14 @@ class EpubToAudiobook:
         if engine == "xtts":
             if (
                 torch.cuda.is_available()
-                and torch.cuda.get_device_properties(0).total_memory > 3500000000
+# Skip VRAM check for now
+#               and torch.cuda.get_device_properties(0).total_memory > 3500000000
             ):
                 print("Using GPU")
+                print("VRAM: " + str(torch.cuda.get_device_properties(0).total_memory))
                 self.device = "cuda"
             else:
-                print("Not enough VRAM on GPU. Using CPU")
+                print("Not enough VRAM on GPU or GPU not found. Using CPU")
                 self.device = "cpu"
 
             print("Loading model: " + self.xtts_model)

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -303,14 +303,13 @@ class EpubToAudiobook:
         if engine == "xtts":
             if (
                 torch.cuda.is_available()
-# Skip VRAM check for now
-#               and torch.cuda.get_device_properties(0).total_memory > 3500000000
+                and torch.cuda.get_device_properties(0).total_memory > 3500000000
             ):
                 print("Using GPU")
                 print("VRAM: " + str(torch.cuda.get_device_properties(0).total_memory))
                 self.device = "cuda"
             else:
-                print("Not enough VRAM on GPU or GPU not found. Using CPU")
+                print("Not enough VRAM on GPU or CUDA not found. Using CPU")
                 self.device = "cpu"
 
             print("Loading model: " + self.xtts_model)
@@ -419,7 +418,10 @@ class EpubToAudiobook:
                                         self.tts.tts_to_file(
                                             text=sentence_groups[x], file_path=tempwav
                                         )
-                                ratio = self.compare(sentence_groups[x], tempwav)
+                                if self.minratio > 0:
+                                    ratio = self.compare(sentence_groups[x], tempwav)
+                                else:
+                                    ratio = self.minratio
                                 if ratio < self.minratio:
                                     raise Exception(
                                         "Spoken text did not sound right - "
@@ -590,7 +592,7 @@ def main():
         nargs="?",
         const=88,
         default=88,
-        help="Minimum match ratio between text and transcript",
+        help="Minimum match ratio between text and transcript, 0 to disable whisper",
     )
     parser.add_argument(
         "--skiplinks", 

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -326,6 +326,7 @@ class EpubToAudiobook:
             )
 
             if self.device == "cuda":
+                print("VRAM: " + str(torch.cuda.get_device_properties(0).total_memory))
                 self.model.cuda()
 
             print("Computing speaker latents...")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.2.2",
+    version="2.2.3",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.2.3",
+    version="2.2.4",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
This allows the user to disable the step that uses whisper to make a transcript of the output, and compares it to the original text, by adding:
`--minratio 0`
when calling epub2tts