### PR TITLE
Fixing issues that broke openAI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.2.8",
+    version="2.2.9",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
Makes OpenAI work again by recognizing file coming back is an mp3, but ffmpeg was expecting it to be a wave. Also force speaker name to lower-case (which OpenAI expects). AND finally, skip whisper transcript comparison if we're using OpenAI.