### PR TITLE
dont try to send an empty sentence to TTS

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -161,6 +161,9 @@ class EpubToAudiobook:
             .replace(":", ", ")
             .replace("''", ", ")
             .replace("’", "'")
+            .replace('“', '"')
+            .replace('”', '"')
+            .replace("◇", "")
             .replace(" . . . ", ", ")
             .replace("... ", ", ")
             .replace("«", " ")
@@ -385,6 +388,8 @@ class EpubToAudiobook:
                     length = 1000
                 sentence_groups = list(self.combine_sentences(sentences, length))
                 for x in tqdm(range(len(sentence_groups))):
+                    if len(sentence_groups[x]) == 0:
+                        continue
                     retries = 2
                     tempwav = "temp" + str(x) + ".wav"
                     tempflac = tempwav.replace("wav", "flac")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.2.10",
+    version="2.2.11",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
If the list of sentences to speak has an empty item in it, TTS will crash when asked to speak that. This adds a check for length of sentence to speak, and skips if the length is 0.