### PR TITLE
Add initial support for Metal Performance Shaders backend.

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -80,6 +80,8 @@ class EpubToAudiobook:
         self.ffmetadatafile = "FFMETADATAFILE"
         if torch.cuda.is_available():
             self.device = "cuda"
+        elif torch.backends.mps.is_available():
+            self.device = "mps"
         else:
             self.device = "cpu"
         # Make sure we've got nltk punkt
@@ -371,6 +373,9 @@ class EpubToAudiobook:
                 print("Using GPU")
                 print(f"VRAM: {torch.cuda.get_device_properties(0).total_memory}")
                 self.device = "cuda"
+            elif torch.backends.mps.is_available():
+                self.device = "mps"
+                print("Using GPU")
             else:
                 print("Not enough VRAM on GPU or CUDA not found. Using CPU")
                 self.device = "cpu"
@@ -558,6 +563,7 @@ class EpubToAudiobook:
             )
             gc.collect()
             torch.cuda.empty_cache()
+            torch.mps.empty_cache()
         outputm4a = self.output_filename.replace("m4b", "m4a")
         filelist = "filelist.txt"
         with open(filelist, "w") as f:


### PR DESCRIPTION
It works generally well on Apple Silicon. However there are pytorch operators, such as 'aten::_weight_norm_interface', which are not currently implemented for the MPS device. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op.

Similarly, when the XTTS engine is selected, MPS does not compose nicely with deepspeed, because features such as redirects (i.e., torch.distributed.elastic.multiprocessing.redirects) are not implemented on the CPU backend for Windows and MacOs at the time of writing. Run alongside --no-deepspeed option at the command line, where needed.

Everything else stays the same.

Committer: Alfonso De Gregorio <adg@secYOUre.com>