### PR TITLE
escape single quote for ffmpeg concat list

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -562,6 +562,7 @@ class EpubToAudiobook:
         filelist = "filelist.txt"
         with open(filelist, "w") as f:
             for filename in files:
+                filename = filename.replace("'", "'\\''")
                 f.write(f"file '{filename}'\n")
         ffmpeg_command = [
             "ffmpeg",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.3.6",
+    version="2.3.7",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
This fixes an issue where if a filename had a single quote in it, ffmpeg would choke. This properly escapes that single quote for ffmpeg's concat file list.