### PR TITLE
Remove condition to add 2 second silence only for epub

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you've found something new, please open an issue and be sure to include:
 <details>
 <summary>Release notes </summary>
 
+* 20240131: [Repaired missing pause between chapters](https://github.com/aedocw/epub2tts/issues/204)
 * 20240114: Updated README
 * 20240111: Added support for Title & Author in text files
 * 20240110: Added support for "--cover image.jpg"

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -594,9 +594,8 @@ class EpubToAudiobook:
                 for chunkindex, chunk in enumerate(tqdm(chunks)):
                     audio_modified += chunk
                     audio_modified += one_sec_silence
-                # add extra 2sec silence at the end of each part/chapter if it's an epub
-                if self.sourcetype == "epub":
-                    audio_modified += two_sec_silence
+                # add extra 2sec silence at the end of each part/chapter
+                audio_modified += two_sec_silence
                 # Write modified audio to the final audio segment
                 audio_modified.export(outputwav, format="wav")
                 for f in tempfiles:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.3.12",
+    version="2.3.13",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
Ensuring a 3 second pause between each chapter/part was only being honored for epub files. I removed that conditional so it also happens for text based files.