### PR TITLE
Uniform pause after sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you've found something new, please open an issue and be sure to include:
 <details>
 <summary>Release notes </summary>
 
+* 20240222: Implemented pause between sentences, https://github.com/aedocw/epub2tts/issues/208 and https://github.com/aedocw/epub2tts/issues/153
 * 20240131: [Repaired missing pause between chapters](https://github.com/aedocw/epub2tts/issues/204)
 * 20240114: Updated README
 * 20240111: Added support for Title & Author in text files

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -286,8 +286,8 @@ class EpubToAudiobook:
                     chunk.to(device=self.device)
                 )  # Move chunk to available device
             # Add a short pause between sentences (e.g., X.XX seconds of silence)
-            if i < len(sentence_list) - 1:
-                silence_duration = int(24000 * 1.0)
+            if i < len(sentence_list):
+                silence_duration = int(24000 * .8)
                 silence = torch.zeros(
                     (silence_duration,), dtype=torch.float32, device=self.device
                 )  # Move silence tensor to available device
@@ -321,15 +321,20 @@ class EpubToAudiobook:
         ) if self.debug else None
         return ratio
 
+#    def combine_sentences(self, sentences, length=1000):
+#        combined = ""
+#        for sentence in sentences:
+#            if len(combined) + len(sentence) <= length:
+#                combined += sentence + " "
+#            else:
+#                yield combined
+#                combined = sentence
+#        yield combined
+
     def combine_sentences(self, sentences, length=1000):
-        combined = ""
         for sentence in sentences:
-            if len(combined) + len(sentence) <= length:
-                combined += sentence + " "
-            else:
-                yield combined
-                combined = sentence
-        yield combined
+            yield sentence
+
 
     def export(self, format):
         allowed_formats = ["txt"]

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -287,7 +287,7 @@ class EpubToAudiobook:
                 )  # Move chunk to available device
             # Add a short pause between sentences (e.g., X.XX seconds of silence)
             if i < len(sentence_list):
-                silence_duration = int(24000 * .8)
+                silence_duration = int(24000 * .6)
                 silence = torch.zeros(
                     (silence_duration,), dtype=torch.float32, device=self.device
                 )  # Move silence tensor to available device

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -321,20 +321,9 @@ class EpubToAudiobook:
         ) if self.debug else None
         return ratio
 
-#    def combine_sentences(self, sentences, length=1000):
-#        combined = ""
-#        for sentence in sentences:
-#            if len(combined) + len(sentence) <= length:
-#                combined += sentence + " "
-#            else:
-#                yield combined
-#                combined = sentence
-#        yield combined
-
     def combine_sentences(self, sentences, length=1000):
         for sentence in sentences:
             yield sentence
-
 
     def export(self, format):
         allowed_formats = ["txt"]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.3.13",
+    version="2.3.14",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
This PR takes work suggested in two different issues (https://github.com/aedocw/epub2tts/issues/153 and https://github.com/aedocw/epub2tts/issues/208), and adds a 0.6sec pause after each sentence. This will also limit the length of text sent to TTS which will likely eliminate the "character limit" error sometimes seen.

This does seem to make a really nice improvement in the overall quality.