### PR TITLE
Bail if first chapter marker is missing

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -770,6 +770,14 @@ class EpubToAudiobook:
                 metadata['Author'] = line.replace('Author: ', '').strip()
                 lines.remove(line)  # Remove line from the original list
 
+        # Check for the next non-whitespace line
+        for line in lines:
+            if line.strip():  # Find the first non-empty line
+                if not line.startswith('#'):
+                    print("Error: The first non-whitespace line must start with '#'")
+                    sys.exit(1)  # Exit the script if the condition is not met
+                break  # Exit the loop once the condition is met
+
         text = '\n'.join(lines)   # Join the lines back
         return metadata, text
     def read_book(self, voice_samples, engine, openai, model_name, speaker, bitrate):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.6.2",
+    version="2.6.3",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
If using text file as source, the first line of the copy must be a chapter marker like `# Intro` or something. Bail if that is missing.