### PR TITLE
Adding .srt support

### DIFF
--- a/epub2tts.py
+++ b/epub2tts.py
@@ -954,9 +954,9 @@ class EpubToAudiobook:
                     for start_ms, len_ms, text in chapter_text_timings:
                         sentance_no += 1
                         end_ms = start_ms + len_ms
-                        delta_start = timedelta(milliseconds=start_ms)
+                        delta_start = timedelta(milliseconds=start_ms+chapter_ofset)
                         formatted_start = f"{delta_start.seconds // 3600:02}:{(delta_start.seconds % 3600) // 60:02}:{delta_start.seconds % 60:02},{delta_start.microseconds // 1000:03}"
-                        delta_end = timedelta(milliseconds=end_ms)
+                        delta_end = timedelta(milliseconds=end_ms+chapter_ofset)
                         formatted_end = f"{delta_end.seconds // 3600:02}:{(delta_end.seconds % 3600) // 60:02}:{delta_end.seconds % 60:02},{delta_end.microseconds // 1000:03}"
                         srt.write(f"{sentance_no}\n")
                         srt.write(f"{formatted_start} --> {formatted_end}\n")

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -544,7 +544,7 @@ class EpubToAudiobook:
         output = re.sub(r'\s{1,}', ' ', raw_text) #remove any place with more than one space HTML only renders one space even if there are many
         output = output.replace("HTMLENTER_MAGIC_STR_ENTER", "\n") #insert enters that come from HTML block elements
         output = re.sub(r'\s{3,}', "\n\n", output) #Remove execive nr of newlines
-        output = output.replace("\n ", "\n").strip() #Remove space in beginin of newline and strip whitespace in the ends of the string
+        output = output.replace("\n ", "\n").replace(" \n", "\n").strip() #Remove space in beginin of newline and strip whitespace in the ends of the string
         return output
 
     def prep_text(self, text_in):

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -944,19 +944,20 @@ class EpubToAudiobook:
             chapter_ofset = 0
             sentance_no = 0
             for filename in files:
-                with open(filename+".timing", "wb") as fp:
+                with open(filename+".timing", "rb") as fp:
                     chapter_text_timings = pickle.load(fp)
                     end_ms = 0
-                    for text, start_ms, len_ms in chapter_text_timings:
+                    for start_ms, len_ms, text in chapter_text_timings:
                         sentance_no += 1
                         end_ms = start_ms + len_ms
                         delta_start = timedelta(milliseconds=start_ms)
                         formatted_start = f"{delta_start.seconds // 3600:02}:{(delta_start.seconds % 3600) // 60:02}:{delta_start.seconds % 60:02},{delta_start.microseconds // 1000:03}"
                         delta_end = timedelta(milliseconds=end_ms)
                         formatted_end = f"{delta_end.seconds // 3600:02}:{(delta_end.seconds % 3600) // 60:02}:{delta_end.seconds % 60:02},{delta_end.microseconds // 1000:03}"
-                        f.write(f"{sentance}\n")
-                        f.write(f"{formatted_start} --> {formatted_end}\n")
-                        f.write(f"{text}\n\n")
+                        srt.write(f"{sentance_no}\n")
+                        srt.write(f"{formatted_start} --> {formatted_end}\n")
+                        clean_text = text.replace("\n", " ")
+                        srt.write(f"{clean_text}\n\n")
                         
                         
                     chapter_ofset += end_ms

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -1,6 +1,7 @@
 import argparse
 import re
 import asyncio
+import pickle
 import os
 import copy
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"]="1"
@@ -351,7 +352,9 @@ def process_book_chapter(dat):
         sound_len_ms = get_duration(file_name)
         time_ofset += sound_len_ms
         text_timings.append((sound_start_ms, sound_len_ms, text))
-    #TODO: save text_timings to a .srt file
+    
+    with open(dat['outputwav']+".timing", "wb") as fp:
+        pickle.dump(text_timings, fp)
    
     join_temp_files_to_chapter(dat['tempfiles'], dat['outputwav'])
     print("done chapter: ", dat['chapter'])

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -333,6 +333,10 @@ def join_temp_files_to_chapter(tempfiles, outputwav):
     for chunkindex, chunk in enumerate(chunks):
         audio_modified += chunk
         audio_modified += one_sec_silence
+
+    if len(chunks) != 1:
+        print("Warning, parts with silence was removed .srt will be out of sync")
+        
     # add extra 2sec silence at the end of each part/chapter
     audio_modified += two_sec_silence
     # Write modified audio to the final audio segment
@@ -961,6 +965,7 @@ class EpubToAudiobook:
                         
                         
                     chapter_ofset += end_ms
+                    chapter_ofset += 2000 #We always add 2s of silence after each chapter, so we account for that
 
         for i in self.audioformat:
             if i == "wav":

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -329,24 +329,24 @@ def join_temp_files_to_chapter(tempfiles, outputwav):
     chunks = split_on_silence(
         concatenated, min_silence_len=1000, silence_thresh=-50
     )
-    msec_removed = 0
+    msec_added = 0
     # Iterate through each chunk
     for chunkindex, chunk in enumerate(chunks):
         audio_modified += chunk
         audio_modified += one_sec_silence
-        msec_removed += 1000
+        msec_added += 1000
 
     if len(chunks) != 1:
         print("Warning, parts with silence was removed .srt will be out of sync")
         
     # add extra 2sec silence at the end of each part/chapter
-    msec_removed += 2000
+    msec_added += 2000
     audio_modified += two_sec_silence
     # Write modified audio to the final audio segment
     audio_modified.export(outputwav, format="wav")
     for f in tempfiles:
         os.remove(f)
-    return msec_removed
+    return msec_added
 
 def process_book_chapter(dat):
     print("initiating chapter: ", dat['chapter'])

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -966,6 +966,7 @@ class EpubToAudiobook:
                         
                     chapter_ofset += end_ms
                     chapter_ofset += 2000 #We always add 2s of silence after each chapter, so we account for that
+                    chapter_ofset += 1000 #there is always one "silence chunk", so we acount for that to
 
         for i in self.audioformat:
             if i == "wav":

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -2,6 +2,7 @@ import argparse
 import re
 import asyncio
 import pickle
+from datetime import timedelta
 import os
 import copy
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"]="1"
@@ -949,8 +950,12 @@ class EpubToAudiobook:
                     for text, start_ms, len_ms in chapter_text_timings:
                         sentance_no += 1
                         end_ms = start_ms + len_ms
+                        delta_start = timedelta(milliseconds=start_ms)
+                        formatted_start = f"{delta_start.seconds // 3600:02}:{(delta_start.seconds % 3600) // 60:02}:{delta_start.seconds % 60:02},{delta_start.microseconds // 1000:03}"
+                        delta_end = timedelta(milliseconds=end_ms)
+                        formatted_end = f"{delta_end.seconds // 3600:02}:{(delta_end.seconds % 3600) // 60:02}:{delta_end.seconds % 60:02},{delta_end.microseconds // 1000:03}"
                         f.write(f"{sentance}\n")
-                        f.write(f"{start_ms} --> 00:31:39,928\n")
+                        f.write(f"{formatted_start} --> {formatted_end}\n")
                         f.write(f"{text}\n\n")
                         
                         

--- a/epub2tts.py
+++ b/epub2tts.py
@@ -939,6 +939,23 @@ class EpubToAudiobook:
                 filename = filename.replace("'", "'\\''")
                 f.write(f"file '{filename}'\n")
 
+        with open(self.output_filename+".srt", "w", encoding='utf8') as srt:
+            chapter_ofset = 0
+            sentance_no = 0
+            for filename in files:
+                with open(filename+".timing", "wb") as fp:
+                    chapter_text_timings = pickle.load(fp)
+                    end_ms = 0
+                    for text, start_ms, len_ms in chapter_text_timings:
+                        sentance_no += 1
+                        end_ms = start_ms + len_ms
+                        f.write(f"{sentance}\n")
+                        f.write(f"{start_ms} --> 00:31:39,928\n")
+                        f.write(f"{text}\n\n")
+                        
+                        
+                    chapter_ofset += end_ms
+
         for i in self.audioformat:
             if i == "wav":
                 outputm4a = outputm4a.replace(".m4a", "_without_metadata.wav")
@@ -1005,6 +1022,7 @@ class EpubToAudiobook:
             os.remove(self.ffmetadatafile)
             for f in files:
                 os.remove(f)
+                os.remove(f+".timing")
         print(self.output_filename + " complete")
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="doc@aedo.net",
     url="https://github.com/aedocw/epub2tts",
     license="Apache License, Version 2.0",
-    version="2.6.3",
+    version="2.7.0",
     packages=find_packages(),
     install_requires=requirements,
     py_modules=["epub2tts"],


### PR DESCRIPTION
Would be nice to be able to view the text sentence by sentence as it is spoken.

One way to save such data is a .srt file.

This PR intends to add .srt file support to epub2tts.

Things to do:

- [x] Save timings for all sentences in each chapter in to temp files
- [x] Correct the timings for silence removal. (or disable silence removal)
- [x] Concatenate all the individual temp timing chapter files in to a final big .srt file